### PR TITLE
fastavro 1.4.7

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,6 @@ requirements:
 test:
   requires:
     - flake8
-    - mypy
     - pip
   imports:
     - fastavro

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.4.3" %}
+{% set version = "1.4.7" %}
 
 package:
   name: fastavro
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/f/fastavro/fastavro-{{ version }}.tar.gz
-  sha256: e9125c5f08e20094b296b8984ac1be9bc6668917152ac2fe044376dacb03012f
+  sha256: a3835f2dba148f838a5412ad64cfcf47d3d8330cbd913a51f269c04984361f85
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,7 @@ source:
 
 build:
   number: 0
+  skip: True  # [py<36]
   script:
     - export FASTAVRO_USE_CYTHON=1  # [not win]
     - set FASTAVRO_USE_CYTHON=1  # [win]
@@ -20,7 +21,6 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-    - python
   host:
     - python
     - cython
@@ -33,8 +33,8 @@ requirements:
 
 test:
   requires:
-    - nose
     - flake8
+    - mypy
     - pip
   imports:
     - fastavro


### PR DESCRIPTION
Update fastavro to 1.4.7

Version change: bump version number from 1.4.3 to 1.4.7
Requirements from conda-forge: https://github.com/conda-forge/fastavro-feedstock/blob/master/recipe/meta.yaml
Bug Tracker: new open issues https://github.com/fastavro/fastavro/issues
Upstream license:  License file:  https://github.com/fastavro/fastavro/blob/master/LICENSE
Upstream Changelog: https://github.com/fastavro/fastavro/blob/master/ChangeLog
Upstream setup.py:  https://github.com/fastavro/fastavro/blob/1.4.7/setup.py

The package fastavro is mentioned inside the packages:
 python-hdfs |

Actions:
1. Skip py<36

Result:
- all-succeeded