### PR TITLE
Version 1.9.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,1 @@
+aggregate_branch: 3.12

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ build:
   script:
     - export FASTAVRO_USE_CYTHON=1  # [not win]
     - set FASTAVRO_USE_CYTHON=1  # [win]
-    - {{ PYTHON }} -m pip install . --no-deps -vv
+    - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - fastavro = fastavro.__main__:main
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "fastavro" %}
-{% set version = "1.7.0" %}
+{% set version = "1.9.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,11 +7,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/fastavro-{{ version }}.tar.gz
-  sha256: 4b1205f46489b4032d3155c1ab44d9824be0c7454df98d3a5bd22b78b98f23c8
+  sha256: f37011d66de8ba81b26760db0478009a14c08ebfd34269b3390abfd4616b308f
 
 build:
   number: 0
-  skip: True  # [py<37]
+  skip: True  # [py<38]
   script:
     - export FASTAVRO_USE_CYTHON=1  # [not win]
     - set FASTAVRO_USE_CYTHON=1  # [win]


### PR DESCRIPTION
fastavro 1.9.1

**Destination channel:** defaults

### Links

- [PKG-3332](https://anaconda.atlassian.net/browse/PKG-3332)
- [Upstream repository](https://github.com/fastavro/fastavro/tree/1.9.1)
- [Upstream changelog/diff](https://github.com/fastavro/fastavro/blob/1.9.1/ChangeLog)

### Explanation of changes:

- Bump version to `1.9.1`
- Update Python skip to `<38`


[PKG-3332]: https://anaconda.atlassian.net/browse/PKG-3332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ